### PR TITLE
Use setDBIMethod()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,13 +15,14 @@ LazyData: true
 Depends:
   R (>= 3.1.0)
 Imports:
-  DBI,
+  DBI (>= 1.0.0.9003),
   RPostgres,
   methods
 Suggests:
   DBItest, testthat
 RoxygenNote: 6.0.1
 Collate: 
+    's4.R'
     'GreenplumDriver.R'
     'GreenplumConnection.R'
     'table-create.R'

--- a/R/GreenplumDriver.R
+++ b/R/GreenplumDriver.R
@@ -1,3 +1,6 @@
+#' @include s4.R
+NULL
+
 #' Greenplum driver
 #'
 #' This driver never needs to be unloaded and hence `dbUnload()` is a

--- a/R/s4.R
+++ b/R/s4.R
@@ -1,0 +1,1 @@
+setMethod <- DBI::setDBIMethod


### PR DESCRIPTION
I'd like to rename the `con` argument to `sqlData()` to `conn` in r-dbi/DBI#285. This change allows me to do so in the future without introducing a breaking change which would be very unpleasant to deal with. Also, it opens up the potential to clean up the definition of the DBI interface.

See https://dbi.r-dbi.org/dev/reference/setdbimethod for details.